### PR TITLE
(fix) when multi client connect to the server

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ export default function(opts = {}) {
 
         if(old == JSON.stringify(ctx.session)) return;
         if(id) await opts.store.destroy(id);
+        opts.sid = id;
         if(ctx.session && Object.keys(ctx.session).length) {
             let sid = await opts.store.set(ctx.session, opts);
             ctx.cookies.set(opts.key, sid, opts);


### PR DESCRIPTION
When current session context changed, should store it by the sid of current session which is get from the request cookies, otherwise the last client will over write the prev one' session info.

Case:
first , use Chrome as client 1, then use IE as client 2 connect to the server.
the store.session only contain one key, the client 2  will overwrite the client 1, because the opts.sid is global.
