### PR TITLE
Fixed Bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,7 @@ module.exports = (opts = {}) => {
 
             // destory old session
             if(id) return opts.store.destroy(id);
-            
-        }).then(() => {
+
             // clear id
             id = null;
 
@@ -46,6 +45,5 @@ module.exports = (opts = {}) => {
                 });
             }
         });
-
     }
 };

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = (opts = {}) => {
             if(old == JSON.stringify(ctx.session)) return;
 
             // destory old session
-            if(id) return opts.store.destroy(id).then(() => {
+            if (id) opts.store.destroy(id).then(() => {
                 // clear id
                 id = null;
             });

--- a/index.js
+++ b/index.js
@@ -30,29 +30,21 @@ module.exports = (opts = {}) => {
             return next();
         }).then(() => {
             // no modify
-            if(old == JSON.stringify(ctx.session)) return;
+            if(old == JSON.stringify(ctx.session)) throw new Error();
 
             // destory old session
-            if(id) {
-                opts.store.destroy(id).then(() => {
-                // clear id
-                id = null;
+            if(id) return opts.store.destroy(id);
 
-                if(ctx.session && Object.keys(ctx.session).length) {
-                    // set new session
-                    return opts.store.set(ctx.session, Object.assign({}, opts, {sid: id})).then(sid => {
-                        ctx.cookies.set(opts.key, sid, opts)
-                    });
-                }
-            });
-            } else {
-                if(ctx.session && Object.keys(ctx.session).length) {
-                    // set new session
-                    return opts.store.set(ctx.session, Object.assign({}, opts, {sid: id})).then(sid => {
-                        ctx.cookies.set(opts.key, sid, opts)
-                    });
-                }
+        }).then(() => {
+            // clear id
+            id = null;
+
+            if(ctx.session && Object.keys(ctx.session).length) {
+                // set new session
+                return opts.store.set(ctx.session, Object.assign({}, opts, {sid: id})).then(sid => {
+                    ctx.cookies.set(opts.key, sid, opts)
+                });
             }
-        });
+        }).catch(err => {});
     }
 };

--- a/index.js
+++ b/index.js
@@ -36,14 +36,14 @@ module.exports = (opts = {}) => {
             if(id) return opts.store.destroy(id).then(() => {
                 // clear id
                 id = null;
-
-                if(ctx.session && Object.keys(ctx.session).length) {
-                    // set new session
-                    return opts.store.set(ctx.session, Object.assign({}, opts, {sid: id})).then(sid => {
-                        ctx.cookies.set(opts.key, sid, opts)
-                    });
-                }
             });
+
+            if(ctx.session && Object.keys(ctx.session).length) {
+                // set new session
+                return opts.store.set(ctx.session, Object.assign({}, opts, {sid: id})).then(sid => {
+                    ctx.cookies.set(opts.key, sid, opts)
+                });
+            }
         });
     }
 };

--- a/index.js
+++ b/index.js
@@ -33,17 +33,17 @@ module.exports = (opts = {}) => {
             if(old == JSON.stringify(ctx.session)) return;
 
             // destory old session
-            if(id) return opts.store.destroy(id);
+            if(id) return opts.store.destroy(id).then(() => {
+                // clear id
+                id = null;
 
-            // clear id
-            id = null;
-
-            if(ctx.session && Object.keys(ctx.session).length) {
-                // set new session
-                return opts.store.set(ctx.session, Object.assign({}, opts, {sid: id})).then(sid => {
-                    ctx.cookies.set(opts.key, sid, opts)
-                });
-            }
+                if(ctx.session && Object.keys(ctx.session).length) {
+                    // set new session
+                    return opts.store.set(ctx.session, Object.assign({}, opts, {sid: id})).then(sid => {
+                        ctx.cookies.set(opts.key, sid, opts)
+                    });
+                }
+            });
         });
     }
 };

--- a/index.js
+++ b/index.js
@@ -33,16 +33,25 @@ module.exports = (opts = {}) => {
             if(old == JSON.stringify(ctx.session)) return;
 
             // destory old session
-            if (id) opts.store.destroy(id).then(() => {
+            if(id) {
+                opts.store.destroy(id).then(() => {
                 // clear id
                 id = null;
-            });
 
-            if(ctx.session && Object.keys(ctx.session).length) {
-                // set new session
-                return opts.store.set(ctx.session, Object.assign({}, opts, {sid: id})).then(sid => {
-                    ctx.cookies.set(opts.key, sid, opts)
-                });
+                if(ctx.session && Object.keys(ctx.session).length) {
+                    // set new session
+                    return opts.store.set(ctx.session, Object.assign({}, opts, {sid: id})).then(sid => {
+                        ctx.cookies.set(opts.key, sid, opts)
+                    });
+                }
+            });
+            } else {
+                if(ctx.session && Object.keys(ctx.session).length) {
+                    // set new session
+                    return opts.store.set(ctx.session, Object.assign({}, opts, {sid: id})).then(sid => {
+                        ctx.cookies.set(opts.key, sid, opts)
+                    });
+                }
             }
         });
     }


### PR DESCRIPTION
There some different between babel version and node6 version, that make node6 version set a new session every time.

babel:

        await next();

        // if not changed
        if(old == JSON.stringify(ctx.session)) return;   ** finish **

        // clear old session if exists
        if(id) {
            await opts.store.destroy(id);
            id = null;
        }

        // set new session
        if(ctx.session && Object.keys(ctx.session).length) {
            let sid = await opts.store.set(ctx.session, Object.assign({}, opts, {sid: id}));
            ctx.cookies.set(opts.key, sid, opts);
        }


node6: 

        promise.then(() => {
            old = JSON.stringify(ctx.session);

            return next();
        }).then(() => {
            // no modify
            if(old == JSON.stringify(ctx.session)) return;

            // destory old session
            if(id) return opts.store.destroy(id);
            
        }).then(() => {                             ** always through **
            // clear id
            id = null;

            if(ctx.session && Object.keys(ctx.session).length) {
                // set new session
                return opts.store.set(ctx.session, Object.assign({}, opts, {sid: id})).then(sid => {
                    ctx.cookies.set(opts.key, sid, opts)
                });
            }
        });
