### PR TITLE
JSON.parse can throw, so move it inside try

### DIFF
--- a/libs/store.js
+++ b/libs/store.js
@@ -8,15 +8,15 @@ class Store {
     }
 
     decode(string) {
-        if(!string) return "";
+        if(typeof string !== "string") return "";
 
         let session = "";
 
         try{
-            session = new Buffer(string, "base64").toString();
+            session = JSON.parse(new Buffer(string, "base64").toString());
         } catch(e) {}
 
-        return JSON.parse(session);
+        return session;
     }
 
     encode(obj) {


### PR DESCRIPTION
`decode` deals with unsanitized user data, so, it can throw in badly formatted JSON