### PR TITLE
Refactoring store to use native Map and no decoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = (opts = {}) => {
             ctx.session = {};
         } else {
             ctx.session = await store.get(id);
-            // check session should be a no-null object
+            // check session must be a no-null object
             if(typeof ctx.session !== "object" || ctx.session == null) {
                 ctx.session = {};
             }
@@ -26,7 +26,8 @@ module.exports = (opts = {}) => {
         // clear old session if exists
         if(id) {
             await store.destroy(id);
-            id = null;
+            // set it to undefined instead of null to be able to use default parameters at Store
+            id = undefined;
         }
 
         // set new session
@@ -36,3 +37,6 @@ module.exports = (opts = {}) => {
         }
     }
 }
+
+// Reeexport Store to not use reference to internal files
+module.exports.Store = Store;

--- a/libs/store.js
+++ b/libs/store.js
@@ -9,13 +9,13 @@ class Store {
         return randomBytes(length).toString('hex');
     }
 
-    async get(sid) {
+    get(sid) {
         if (!this.sessions.has(sid)) return undefined;
         // We are decoding data coming from our Store, so, we assume it was sanitized before storing
         return JSON.parse(this.sessions.get(sid));
     }
 
-    async set(session, { sid =  this.getID(24), maxAge } = {}) {
+    set(session, { sid =  this.getID(24), maxAge } = {}) {
         // Just a demo how to use maxAge and some cleanup
         if (this.sessions.has(sid)) {
             const { __timeout } = this.sessions.get(sid);
@@ -31,7 +31,7 @@ class Store {
         return sid;
     }
 
-    async destroy(sid) {
+    destroy(sid) {
         this.sessions.delete(sid);
     }
 }


### PR DESCRIPTION
1. You basically simulating native javascript Map object via keys of object - that's bad, it's `node 7x` already, let's use native Map

2. Re-export `Store` from main file to avoid referencing internal project files when extending `Store`.

3. You actually don't need encode & decode session data for in-memory storage, so, dropped it. When extending Store developer must do store specific value sanitation anyway.