### PR TITLE
Fine-tune `packages.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Middleware for Koa2 to get/set session use with custom stores such as Redis or mongodb",
   "main": "index.js",
   "scripts": {
-    "build": "gulp",
     "test": "mocha --harmony",
     "test-cov": "node --harmony node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec"
   },

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "koa-session2",
   "version": "2.1.1",
-  "description": "Middleware for Koa2 to get/set session use with custom stores such as Redis or mongodb with Babel",
-  "main": "dist/index.js",
+  "description": "Middleware for Koa2 to get/set session use with custom stores such as Redis or mongodb",
+  "main": "index.js",
   "scripts": {
     "build": "gulp",
     "test": "mocha --harmony",
@@ -12,6 +12,10 @@
     "type": "git",
     "url": "git+https://github.com/Secbone/koa-session2.git"
   },
+  "files":[
+    "index.js",
+    "libs"
+  ],
   "keywords": [
     "koa2",
     "koa",
@@ -26,14 +30,19 @@
     "url": "https://github.com/Secbone/koa-session2/issues"
   },
   "homepage": "https://github.com/Secbone/koa-session2#readme",
-  "dependencies": {},
   "devDependencies": {
-    "koa": "^2.0.0",
+    "koa": "^2.0.1",
     "koa-router": "^7.0.1",
-    "mocha": "^2.5.3",
-    "supertest": "^1.2.0"
+    "mocha": "^3.2.0",
+    "supertest": "^3.0.0"
+  },
+  "peerDependencies": {
+    "koa": ">=2.0.1"
   },
   "engines": {
-    "node": ">=7.0.0"
-  }
+    "node": ">=7.6.0"
+  },
+  "contributors": [
+    "Tino Vyatkin <tino@vtkn.io>"
+  ]
 }


### PR DESCRIPTION
Some last tunings, after that I believe you can release next `SEMVER-MINOR`:

1. Removed `babel` from package description (you don't use it anymore!)
2. fixed `main`
3. added `files` section to not install tests on `npm install`
4. Bumped devDependencies to latest version
5. added Koa 2.0.1 as peerDependency to prevent using with koa 1.x
6. Fixed `engines` to reflect the same of `koa 2.0.1`

PS:
7. added myselft to `contributors` field